### PR TITLE
Add factories, with command, and multiple hosts

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,8 @@ node_modules/
 config.json
 .DS_Store
 .vscode
+__tests__/
+__mocks__/
 
 # Dependency directory
 # https://docs.npmjs.com/cli/shrinkwrap#caveats

--- a/README.md
+++ b/README.md
@@ -34,9 +34,14 @@ You **must** provide a target for your rocket, but you do not have to provide a 
 
 ```javascript
 const rocket = require('rcktship');
-const config = require('./config.json');
 
-rocket.target('prod', config.connection);
+rocket.target('prod', [{
+  "host": "foo@bar.buz",
+  "port": 22,
+  "username": "foobar",
+  "privateKey": "/Users/foobar",
+  "passphrase": "*****"
+}]);
 
 rocket.mission('default', () => {
   console.log('Default mission!');
@@ -57,6 +62,8 @@ $ rocket prod
 # Run pwd task
 $ rocket prod pwd
 ```
+
+Connection objects used for targets are ConnectConfig from [SSH2](https://github.com/mscdex/ssh2). Look there for any documentation on connection configurations.
 
 ## Development
 

--- a/__mocks__/ssh2.js
+++ b/__mocks__/ssh2.js
@@ -1,0 +1,26 @@
+const ssh2 = jest.genMockFromModule('ssh2');
+
+ssh2.Client = class Client {
+  constructor() {
+    this.end = jest.fn();
+    this.exec = jest.fn((command, callback) => {
+      callback({}, new Stream())
+    });
+  }
+  on(event, callback) {
+    callback();
+    return this;
+  }
+
+  connect(config) {
+    return this;
+  }
+}
+
+class Stream {
+  on(event, callback) {
+    callback();
+  }
+}
+
+module.exports = ssh2;

--- a/bin/rocket.js
+++ b/bin/rocket.js
@@ -58,13 +58,13 @@ const cli = new Liftoff({
   v8flags: v8flags,
 });
 
-function invoke(env) {
+async function invoke(env) {
   process.chdir(env.configBase);
 
   if (options.config) env.configPath = options.config;
 
   require(env.configPath);
-  const rcktship = require(env.modulePath);
+  const rcktship = await require(env.modulePath);
   rcktship.liftoff(target, mission).catch((err) => console.error(err));
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rcktship",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rcktship",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "A lightweight library the runs an arbitrary series of shell commands on both local and remote hosts.",
   "scripts": {
     "start": "npm run clean && npm run watch-ts",

--- a/rcktship.js
+++ b/rcktship.js
@@ -1,7 +1,8 @@
 const rocket = require('./index');
 const config = require('./config.json');
 
-rocket.target('prod', config.connection);
+rocket.target('prod', [config.connection]);
+rocket.target('prod2', [config.connection, config.connection])
 
 rocket.mission('default', () => {
   console.log('Default mission!');
@@ -10,6 +11,16 @@ rocket.mission('default', () => {
 });
 
 rocket.mission('pwd', () => {
-  rocket.local('pwd');
+  rocket.remote('pwd');
+  rocket.remote('hostname');
+});
+
+rocket.mission('with', () => {
+  rocket.with('cd /app', () => {
+    rocket.with('cd /', () => {
+      rocket.remote('pwd');
+    })
+    rocket.remote('pwd');
+  });
   rocket.remote('pwd');
 });

--- a/src/ConnectionFactory.ts
+++ b/src/ConnectionFactory.ts
@@ -1,0 +1,39 @@
+import { Client, ConnectConfig } from 'ssh2';
+import { readFileSync } from 'fs';
+import { connect } from 'net';
+
+class ConnectionFactory {
+  create(config: ConnectConfig): Promise<Client> {
+    config = Object.assign({}, config);
+    if (config.privateKey)
+      config.privateKey = readFileSync(config.privateKey);
+    return new Promise<Client>((resolve, reject) => {
+      let connection = new Client();
+      connection.on('ready', () => {
+        resolve(connection);
+      }).connect(config);
+    })
+  }
+
+  createAll(configs: ConnectConfig[]): Promise<Client[]> {
+    return new Promise<Client[]>(async (resolve, reject) => {
+      const connections: Client[] = [];
+      for (const config of configs) {
+        connections.push(await this.create(config));
+      }
+      resolve(connections);
+    });
+  }
+
+  terminate(connection: Client) {
+    connection.end();
+  }
+
+  terminateAll(connections: Client[]) {
+    for (let connection of connections) {
+      this.terminate(connection);
+    }
+  }
+}
+
+export { ConnectionFactory };

--- a/src/Rocket.ts
+++ b/src/Rocket.ts
@@ -6,40 +6,89 @@ const colors = chalk.default;
 import { AbstractCommand } from './commands/AbstractCommand';
 import { LocalCommand } from './commands/LocalCommand';
 import { RemoteCommand } from './commands/RemoteCommand';
+import { ConnectionFactory } from './ConnectionFactory';
+
 
 class Rocket {
-  cmds: AbstractCommand[] = [];
-  conn: Client;
   currentTarget: string;
-  targets: { [target: string]: ConnectConfig } = {};
+  commands: AbstractCommand[] = [];
+  connections: Client[] = [];
+  targets: { [target: string]: ConnectConfig[] } = {};
   missions: { [name: string]: Function } = {};
+  prependArgs: string[] = [];
 
-  target(target: string, rocketConfig: ConnectConfig) {
-    if (rocketConfig && rocketConfig.privateKey)
-      rocketConfig.privateKey = readFileSync(rocketConfig.privateKey);
-    this.targets[target] = rocketConfig;
+  constructor(private connectionFactory: ConnectionFactory) { }
+
+  /**
+   * Add a new target that the rocket can use to execute commands on
+   *
+   * @param target The name of the target
+   * @param connectionConfigs Connections for each host this target should hit
+   */
+  target(target: string, connectionConfigs: ConnectConfig[]) {
+    this.targets[target] = connectionConfigs;
   }
 
+  /**
+   * Run a command on all remote hosts in the target
+   *
+   * @param cmd Command to run remotely
+   */
   remote(cmd: string) {
+    cmd = this.composeCmd(cmd);
     const remoteCmd = new RemoteCommand(cmd);
     this.addToQueue(remoteCmd);
   }
 
+  /**
+   * Run a command locally, once
+   *
+   * @param cmd Command to run locally
+   */
   local(cmd: string) {
+    cmd = this.composeCmd(cmd);
     const localCmd = new LocalCommand(cmd);
     this.addToQueue(localCmd);
   }
 
+  /**
+   * Create a new mission with a particular name that executes a callback
+   * containing javascript and commands to run
+   *
+   * @param name Name of the mission
+   * @param callback Function to call when executing a mission
+   */
   mission(name: string, callback: Function) {
     this.missions[name] = callback;
   }
 
+  /**
+   * Reset all internal attributes, commands, missions, and targets
+   */
   reset() {
-    this.cmds = [];
+    this.commands = [];
     this.missions = {};
     this.targets = {};
   }
 
+  /**
+   * Prepend all commands inside of a given callback with a given command
+   *
+   * @param command Command to prepend to all commands executed in the callback
+   * @param callback Callback containing commands to execute
+   */
+  with(command: string, callback: Function) {
+    this.prependArgs.push(command);
+    callback();
+    this.prependArgs.pop();
+  }
+
+  /**
+   * Make the rocket liftoff! And run all commands sequentially!
+   *
+   * @param target Target to use when executing commands
+   * @param mission Missions to run on the selected target, default is 'default'
+   */
   async liftoff(target: string, mission = 'default') {
     if (!this.missions[mission]) {
       throw new Error(`${colors.redBright('Mission')}` +
@@ -55,32 +104,31 @@ class Rocket {
 
     const targetConfig = this.targets[target];
     this.currentTarget = target;
-    this.missions[mission]();
-
     if (targetConfig) {
-      this.conn = new Client();
-      this.conn.on('ready', async () => {
-        console.log(colors.blue.bold('Client::ready\n'));
-        await this.runCmds();
-        this.conn.end();
-        console.log(colors.blue.bold('Client::end'));
-      }).connect(targetConfig);
-    } else {
-      await this.runCmds();
+      console.log(colors.blue.bold('Client::ready\n'));
+      this.connections = await this.connectionFactory.createAll(targetConfig);
     }
 
-    return 'success';
+    await this.missions[mission]();
+    await this.runCommands(this.commands);
+
+    if (targetConfig) {
+      await this.connectionFactory.terminateAll(this.connections);
+      console.log(colors.blue.bold('Client::end'));
+    }
+
+    return true;
   }
 
   private addToQueue(cmd: AbstractCommand) {
-    this.cmds.push(cmd);
+    this.commands.push(cmd);
   }
 
-  private async runCmds() {
+  private async runCommands(commands: AbstractCommand[]): Promise<object> {
     return new Promise(async (resolve, reject) => {
-      for (let cmd of this.cmds) {
+      for (let cmd of commands) {
         try {
-          await cmd.execute(this.conn);
+          await this.executeCommand(cmd);
         } catch (err) {
           console.error(colors.redBright.bold(`Failed executing command: ${cmd.cmd}`));
           console.error(colors.redBright(err));
@@ -88,6 +136,24 @@ class Rocket {
       }
       return resolve();
     });
+  }
+
+  private async executeCommand(command: AbstractCommand) {
+    return new Promise(async (resolve, reject) => {
+      let commandExecutions: Promise<object>[] = [];
+      for (let connection of this.connections) {
+        commandExecutions.push(command.execute(connection));
+      }
+      await Promise.all(commandExecutions);
+      resolve();
+    });
+  }
+
+  private composeCmd(cmd: string): string {
+    const prepend = this.prependArgs.join(' && ');
+    if (this.prependArgs.length > 0)
+      cmd = prepend + ' && ' + cmd;
+    return cmd;
   }
 }
 

--- a/src/RocketFactory.ts
+++ b/src/RocketFactory.ts
@@ -1,0 +1,11 @@
+import { Rocket } from './Rocket';
+import { ConnectionFactory } from './ConnectionFactory';
+
+class RocketFactory {
+  create(): Rocket {
+    const connectionFactory = new ConnectionFactory();
+    return new Rocket(connectionFactory);
+  }
+}
+
+export { RocketFactory };

--- a/src/__tests__/ConnectionFactory.test.ts
+++ b/src/__tests__/ConnectionFactory.test.ts
@@ -1,0 +1,20 @@
+import { ConnectionFactory } from '../ConnectionFactory';
+
+const connectionFactory = new ConnectionFactory();
+
+test('Should create a new connection and terminate it', async () => {
+  const connection = await connectionFactory.create({});
+  expect(connection).toBeDefined();
+  connectionFactory.terminate(connection);
+  expect(connection.end).toHaveBeenCalled();
+});
+
+test('Should create multiple new connections', async () => {
+  const connections = await connectionFactory.createAll([{}, {}, {}]);
+  expect(connections).toBeDefined();
+  expect(connections).toHaveLength(3);
+  connectionFactory.terminateAll(connections);
+  for (let connection of connections) {
+    expect(connection.end).toHaveBeenCalled();
+  }
+});

--- a/src/__tests__/Rocket.test.ts
+++ b/src/__tests__/Rocket.test.ts
@@ -1,24 +1,25 @@
-import { Rocket } from '../Rocket';
+import { RocketFactory } from '../RocketFactory';
 import * as chalk from 'chalk';
 
 const colors = chalk.default;
 
-const rocket = new Rocket();
+const rocketFactory = new RocketFactory();
+const rocket = rocketFactory.create();
 
 beforeEach(() => {
   rocket.reset();
 });
 
 test('Should add new local command to queue', () => {
-  expect(rocket.cmds).toHaveLength(0);
+  expect(rocket.commands).toHaveLength(0);
   rocket.local('pwd');
-  expect(rocket.cmds).toHaveLength(1);
+  expect(rocket.commands).toHaveLength(1);
 });
 
 test('Should add new remote command to queue', () => {
-  expect(rocket.cmds).toHaveLength(0);
+  expect(rocket.commands).toHaveLength(0);
   rocket.remote('pwd');
-  expect(rocket.cmds).toHaveLength(1);
+  expect(rocket.commands).toHaveLength(1);
 });
 
 test('Should add a new mission', async () => {
@@ -31,7 +32,7 @@ test('Should add a new mission', async () => {
 
 test('Should add a new target', () => {
   expect(rocket.targets['prod']).toBeUndefined();
-  rocket.target('prod', {});
+  rocket.target('prod', []);
   expect(rocket.targets['prod']).toBeDefined();
 });
 
@@ -42,7 +43,7 @@ test('Should run set of local commands', async () => {
   });
 
   const output = await rocket.liftoff('local');
-  expect(output).toEqual('success');
+  expect(output).toEqual(true);
 });
 
 test('Should throw error if target is not registered', async () => {
@@ -66,4 +67,12 @@ test('Should throw error if mission is not registered', async () => {
   } catch (err) {
     expect(err).toEqual(expected);
   }
+});
+
+test('Using with should add', () => {
+  expect(rocket.prependArgs).toHaveLength(0);
+  rocket.with('cd /test', () => {
+    expect(rocket.prependArgs).toHaveLength(1);
+  });
+  expect(rocket.prependArgs).toHaveLength(0);
 });

--- a/src/__tests__/RocketFactory.test.ts
+++ b/src/__tests__/RocketFactory.test.ts
@@ -1,0 +1,8 @@
+import { RocketFactory } from '../RocketFactory';
+
+const rocketFactory = new RocketFactory();
+
+test('Should create a new rocket', () => {
+  const rocket = rocketFactory.create();
+  expect(rocket).toBeDefined();
+});

--- a/src/commands/__tests__/RemoteCommand.test.ts
+++ b/src/commands/__tests__/RemoteCommand.test.ts
@@ -1,6 +1,15 @@
 import { RemoteCommand } from '../RemoteCommand';
+import { ConnectionFactory } from '../../ConnectionFactory';
+
+const connectionFactory = new ConnectionFactory();
 
 test('RemoteCommand should contain correct command', () => {
   const cmd = new RemoteCommand('pwd');
   expect(cmd.cmd).toEqual('pwd');
+});
+
+test('RemoteCommand should execute safely', async () => {
+  const cmd = new RemoteCommand('pwd');
+  const output = await cmd.execute(await connectionFactory.create({}));
+  expect(output).toEqual('success');
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
+import { RocketFactory } from './RocketFactory';
 import { Rocket } from './Rocket';
 
-const rckt = new Rocket();
+const rocketFactory = new RocketFactory();
+const rckt: Rocket = rocketFactory.create();
 
 export { rckt };


### PR DESCRIPTION
- Add a variety of factory methods in order to abstract things and make code more concise
- Add `rocket.with(cmd, callback)` so we can pre-pend a common command to all commands in the callback
- Add the ability to pass in a list of hosts for each target so remote commands can be run on multiple hosts